### PR TITLE
upgrade ldap api to 2.0.0.AM3 to fix DIRAPI-341 (relaxed schema loader)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.5-SNAPSHOT
 ideaVersion=2018.1
 javaVersion=1.8
-apacheDirectoryApiVersion=2.0.0.AM2
+apacheDirectoryApiVersion=2.0.0.AM3
 
 org.gradle.logging.level=info

--- a/src/org/majki/intellij/ldapbrowser/ldap/LdapNode.java
+++ b/src/org/majki/intellij/ldapbrowser/ldap/LdapNode.java
@@ -103,7 +103,7 @@ public class LdapNode implements Serializable {
 
     private void addValuesFromAttribute(Attribute attribute, List<LdapAttribute.Value> values) {
         for (Value value : attribute) {
-            values.add(new LdapAttribute.Value(value.isNull(), value.isHumanReadable(), value.getValue(), value.getBytes()));
+            values.add(new LdapAttribute.Value(value.isNull(), value.isHumanReadable(), value.getString(), value.getBytes()));
         }
     }
 
@@ -115,7 +115,7 @@ public class LdapNode implements Serializable {
         for (Attribute attribute : rootDse.getAttributes()) {
             if (attribute.getId().equalsIgnoreCase(NAMING_CONTEXT_ATTRIBUTE_NAME)) {
                 for (Value value : attribute) {
-                    LdapNode node = new LdapNode(ldapConnectionInfo, this, topObjectClass, value.getValue(), value.getValue(), new ArrayList<>());
+                    LdapNode node = new LdapNode(ldapConnectionInfo, this, topObjectClass, value.getString(), value.getString(), new ArrayList<>());
                     node.refresh();
                     children.add(node);
                 }


### PR DESCRIPTION
There were an issue with relaxed schema loading within the Ldap API up to 2.0.0AM2. The problem is fixed by LDAP API 2.0.0.AM3 . So i suggest to update dependency to 2.0.0.AM3 as i had problems with LDAP repo containing custom schema types.

see https://issues.apache.org/jira/browse/DIRAPI-341 for details